### PR TITLE
Fix error when a label is replaced by an already existing name

### DIFF
--- a/reposettings.py
+++ b/reposettings.py
@@ -204,8 +204,8 @@ class LabelHook(RepoSetter):
         conf_labels = config['labels']
         unset_labels = conf_labels.copy()
 
-        repolabels = [l for l in repo.get_labels()]  # iter to avoid fetching labels more than once
-        existentLabelNames = {l.name for l in repolabels}
+        repo_labels = [l for l in repo.get_labels()]  # iter to avoid fetching labels more than once
+        repo_labels_names = {l.name for l in repolabels}
         for label in repolabels:
             newname, newsettings = LabelHook.replacement(conf_labels, label)
 

--- a/reposettings.py
+++ b/reposettings.py
@@ -206,7 +206,7 @@ class LabelHook(RepoSetter):
 
         repo_labels = [l for l in repo.get_labels()]  # iter to avoid fetching labels more than once
         repo_labels_names = {l.name for l in repo_labels}
-        for label in repolabels:
+        for label in repo_labels:
             newname, newsettings = LabelHook.replacement(conf_labels, label)
 
             if newname is None: # Not present in config, delete

--- a/reposettings.py
+++ b/reposettings.py
@@ -266,9 +266,8 @@ class LabelHook(RepoSetter):
             return label.name, newset[label.name]
 
         # Otherwise check `replaces` key for all new labels
-        for name in newset:
-            new = newset[name]
-            if 'replaces' in new and label.name in new['replaces']:
+        for name, new in newset.items():
+            if label.name in new.get('replaces', []):
                 return name, new
 
         return None, None

--- a/reposettings.py
+++ b/reposettings.py
@@ -221,8 +221,8 @@ class LabelHook(RepoSetter):
                 try:
                     label.edit(
                         name=newname,
-                        color=newlabel['color'] if 'color' in newlabel else label.color,
-                        description=newlabel['description'] if 'description' in newlabel else label.description,
+                        color=newlabel.get('color', label.color),
+                        description=newlabel.get('description', label.description)
                     )
                     existentLabelNames.add(newname)
                 except Exception as e:
@@ -239,10 +239,8 @@ class LabelHook(RepoSetter):
             try:
                 repo.create_label(
                     name=newname,
-                    color=newlabel['color'] if 'color' in newlabel and newlabel['color'] is not None
-                    else GithubObject.NotSet,
-                    description=newlabel['description'] if 'description' in newlabel and newlabel['description'] is not None
-                    else GithubObject.NotSet,
+                    color=newlabel.get('color') or GithubObject.NotSet,
+                    description=newlabel.get('description') or GithubObject.NotSet,
                 )
             except Exception as e:
                 print(f" Error deleting label: {str(e)}")
@@ -252,12 +250,9 @@ class LabelHook(RepoSetter):
         """
         Checks whether a label needs an update
         """
-        if 'color' in new and new['color'] is not None and label.color != new['color']:
-            return True
-        if 'description' in new and new['description'] is not None and label.description != new['description']:
-            return True
-
-        return False
+        newColor = new.get('color') or label.color
+        newDescription = new.get('description') or label.description
+        return newColor != label.color or newDescription != label.description
 
     @staticmethod
     def replacement(newset: dict, label: Label, existentLabelNames: Container):

--- a/reposettings.py
+++ b/reposettings.py
@@ -205,7 +205,7 @@ class LabelHook(RepoSetter):
         unset_labels = conf_labels.copy()
 
         repo_labels = [l for l in repo.get_labels()]  # iter to avoid fetching labels more than once
-        repo_labels_names = {l.name for l in repolabels}
+        repo_labels_names = {l.name for l in repo_labels}
         for label in repolabels:
             newname, newsettings = LabelHook.replacement(conf_labels, label)
 

--- a/reposettings.py
+++ b/reposettings.py
@@ -205,21 +205,21 @@ class LabelHook(RepoSetter):
         unset_labels = conf_labels.copy()
 
         repo_labels = [l for l in repo.get_labels()]  # iter to avoid fetching labels more than once
-        repo_labels_names = {l.name for l in repo_labels}
+        repo_label_names = {l.name for l in repo_labels}
         for label in repo_labels:
             newname, newsettings = LabelHook.replacement(conf_labels, label)
 
             if newname is None: # Not present in config, delete
                 LabelHook.delete_label(label)
 
-            elif label.name != newname and newname in existentLabelNames:
+            elif label.name != newname and newname in repo_label_names:
                 LabelHook.replace_label_with_existent(repo, label, newname)
 
             elif LabelHook.needs_update(label, newname, newsettings):
                 print(f" Editing label {label.name}")
                 try:
                     LabelHook.update_label(label, newname, newsettings)
-                    existentLabelNames.add(newname)
+                    repo_label_names.add(newname)
                 except Exception as e:
                     print(f" Error editing label: {str(e)}")
                     continue

--- a/test_reposetters.py
+++ b/test_reposetters.py
@@ -387,7 +387,7 @@ class TestLabelHook(unittest.TestCase):
 
         repomock.create_label.assert_has_calls([])
         for i in range(5):
-            if i == 0:
+            if i in (0, 4):
                 labels[i].delete.assert_called_once()
             if i == 1:
                 labels[i].edit.assert_called_once_with(
@@ -402,6 +402,45 @@ class TestLabelHook(unittest.TestCase):
                     description="Test description 2",
                 )
             else:
+                labels[i].edit.assert_has_calls([])
+
+    def test_replacement_by_existent(self):
+        lh = rs.LabelHook()
+
+        labels = []
+        for i in range(2):
+            label = MagicMock()
+            label.color = f"aabb{i}{i}"
+            label.name = f"Test label {i}"
+            label.description = f"Test description {i}"
+            label.edit.return_value = None
+            label.delete.return_value = None
+            labels.append(label)
+
+        repomock = MagicMock()
+        repomock.get_labels.return_value = labels
+        repomock.create_label.return_value = None
+
+        lh.set(repomock, {
+            "labels": {
+                "Replaces TL0 and TL1": {
+                    "description": "Replaced",
+                    "color": "111111",
+                    "replaces": ["Test label 0", "Test label 1"]
+                },
+            }
+        })
+
+        repomock.create_label.assert_has_calls([])
+        for i in range(2):
+            if i == 0:
+                labels[i].edit.assert_called_once_with(
+                    name=f"Replaces TL0 and TL1",
+                    color="111111",
+                    description="Replaced"
+                )
+            else:
+                labels[i].delete.assert_called_once()
                 labels[i].edit.assert_has_calls([])
 
 

--- a/test_reposetters.py
+++ b/test_reposetters.py
@@ -387,8 +387,6 @@ class TestLabelHook(unittest.TestCase):
 
         repomock.create_label.assert_has_calls([])
         for i in range(5):
-            if i in (0, 4):
-                labels[i].delete.assert_called_once()
             if i == 1:
                 labels[i].edit.assert_called_once_with(
                     name=f"Replaces TL1",
@@ -401,7 +399,10 @@ class TestLabelHook(unittest.TestCase):
                     color="aabb22",
                     description="Test description 2",
                 )
+            elif i == 3:
+                labels[i].edit.assert_has_calls([])
             else:
+                labels[i].delete.assert_called_once()
                 labels[i].edit.assert_has_calls([])
 
     def test_replacement_by_existent(self):


### PR DESCRIPTION
The proposed changes address an issue for configurations where a label should replace more than one. Example:

```yaml
  # ...
  kind/feature:
    color: c7def8
    description: new description
    replaces: [ feature, enhancement ]
  # ...
```

When the second label to be replaced is edited we get an error because a label with the same name that the one being edited already exists (`kind/feature` in the example).

To fix it, when the replacement is being found the new label name existence is taken into consideration.