### PR TITLE
support protecting default branch

### DIFF
--- a/reposettings.py
+++ b/reposettings.py
@@ -142,15 +142,17 @@ class BranchProtectionHook(RepoSetter):
         return "Branch protection settings hook"
 
     @staticmethod
-    def set(repo: Repository, config):
+    def set(repo: Repository.Repository, config):
         print(" Processing branch protection settings...")
 
         if 'branch-protection' not in config and 'branch-protection-overrides' not in config:
             print(" Nothing to do.")
             return
 
+        should_protect_default_branch = config.get('protect-default-branch')
+
         for branch in repo.get_branches():
-            if not branch.protected:
+            if not (branch.protected or (should_protect_default_branch and repo.default_branch == branch.name)):
                 continue
 
             rules = BranchProtectionHook.rules_for(branch.name, config)

--- a/reposettings.yml
+++ b/reposettings.yml
@@ -8,6 +8,7 @@ all-settings:
     # Per-branch protection rule overrides. These are _not_ merged with the global rules above, but fully replace them.
     gh-pages:
       required-review-count: 0
+  protect-default-branch: true # If set to true, it will protect the project's default branch applying 'branch-protection' rules
   features:
     issues: true
     projects: true


### PR DESCRIPTION
The proposed changes allow users easily protect the default branch (regardless of its name) in all configured repositories.