### PR TITLE
fix: skip previous protection check on unprotected branches

### DIFF
--- a/reposettings.py
+++ b/reposettings.py
@@ -165,11 +165,12 @@ class BranchProtectionHook(RepoSetter):
             if 'required-review-count' in rules:
                 newsettings['required_approving_review_count'] = int(rules['required-review-count'])
 
-            if not RepoSetter.has_changes(newsettings, branch.get_protection()):
+            # We check changes unless the branch wasn't protected (default branch can be still unprotected)
+            if branch.protected and (not RepoSetter.has_changes(newsettings, branch.get_protection())):
                 print(f" Branch protection settings for {branch.name} unchanged.")
                 continue
 
-            print(" Applying branch protection settings...")
+            print(f" Applying branch protection settings to '{branch.name}'...")
             branch.edit_protection(**newsettings)
 
     @staticmethod

--- a/reposettings.py
+++ b/reposettings.py
@@ -165,10 +165,11 @@ class BranchProtectionHook(RepoSetter):
             if 'required-review-count' in rules:
                 newsettings['required_approving_review_count'] = int(rules['required-review-count'])
 
-            # We check changes unless the branch wasn't protected (default branch can be still unprotected)
-            if branch.protected and (not RepoSetter.has_changes(newsettings, branch.get_protection())):
-                print(f" Branch protection settings for {branch.name} unchanged.")
-                continue
+            # If branch is not protected we cannot get current protection settings, so we cannot call has_changes and must apply changes blindly
+            if branch.protected
+                if not RepoSetter.has_changes(newsettings, branch.get_protection()):
+                    print(f" Branch protection settings for {branch.name} unchanged.")
+                    continue
 
             print(f" Applying branch protection settings to '{branch.name}'...")
             branch.edit_protection(**newsettings)

--- a/reposettings.py
+++ b/reposettings.py
@@ -166,7 +166,7 @@ class BranchProtectionHook(RepoSetter):
                 newsettings['required_approving_review_count'] = int(rules['required-review-count'])
 
             # If branch is not protected we cannot get current protection settings, so we cannot call has_changes and must apply changes blindly
-            if branch.protected
+            if branch.protected:
                 if not RepoSetter.has_changes(newsettings, branch.get_protection()):
                     print(f" Branch protection settings for {branch.name} unchanged.")
                     continue


### PR DESCRIPTION
Even if [this comment](https://github.com/roobre/reposettings/pull/3#discussion_r861052762) proved it is possible to set protection settings to unprotected branches, I missed previous branch protections settings were also checked.

I propose this change to skip that check when the branch wasn't previously protected, and make the `protect-default-branch` setting actually work.