### PR TITLE
reposettings: fix spelling of "`dismiss-stale-reviews`" config option

### DIFF
--- a/reposettings.py
+++ b/reposettings.py
@@ -160,8 +160,13 @@ class BranchProtectionHook(RepoSetter):
             rules = BranchProtectionHook.rules_for(branch.name, config)
 
             newsettings = {}
+            # Historically dismiss has been misspelled as "dissmiss". To avoid breaking config, we read that too and
+            # print a warning.
             if 'dissmiss-stale-reviews' in rules:
+                print(" Warning: using deprecated 'dissmiss-stale-reviews', please replace it with 'dismiss-stale-reviews'")
                 newsettings['dismiss_stale_reviews'] = bool(rules['dissmiss-stale-reviews'])
+            if 'dismiss-stale-reviews' in rules:
+                newsettings['dismiss_stale_reviews'] = bool(rules['dismiss-stale-reviews'])
             if 'required-review-count' in rules:
                 newsettings['required_approving_review_count'] = int(rules['required-review-count'])
 

--- a/test_reposetters.py
+++ b/test_reposetters.py
@@ -82,7 +82,7 @@ class TestBranchProtectionHook(unittest.TestCase):
 
         bh.set(repomock, {
             "branch-protection": {
-                "dissmiss-stale-reviews": True,
+                "dismiss-stale-reviews": True,
                 "required-review-count": 2,
             }
         })
@@ -110,7 +110,7 @@ class TestBranchProtectionHook(unittest.TestCase):
 
         bh.set(repomock, {
             "branch-protection": {
-                "dissmiss-stale-reviews": True,
+                "dismiss-stale-reviews": True,
                 "required-review-count": 2,
             },
             "branch-protection-overrides": {
@@ -140,7 +140,7 @@ class TestBranchProtectionHook(unittest.TestCase):
 
         bh.set(repomock, {
             "branch-protection": {
-                "dissmiss-stale-reviews": True,
+                "dismiss-stale-reviews": True,
                 "required-review-count": 2,
             },
             "branch-protection-overrides": {
@@ -205,7 +205,7 @@ class TestBranchProtectionHook(unittest.TestCase):
 
         bh.set(repomock, {
             "branch-protection": {
-                "dissmiss-stale-reviews": True,
+                "dismiss-stale-reviews": True,
                 "required-review-count": 2,
             },
             "protect-default-branch": True
@@ -218,6 +218,27 @@ class TestBranchProtectionHook(unittest.TestCase):
             )
         unprotectedbranchmock.edit_protection.assert_not_called()
 
+    def test_misspelled_dismiss(self):
+        bh = rs.BranchProtectionHook()
+
+        branchmock = MagicMock()
+        branchmock.name = 'branchmock'
+        branchmock.dismiss_stale_reviews = False
+
+        repomock = MagicMock()
+        repomock.get_branches.return_value = [
+            branchmock
+        ]
+
+        bh.set(repomock, {
+            "branch-protection": {
+                "dissmiss-stale-reviews": True,
+            },
+        })
+
+        branchmock.edit_protection.assert_called_with(
+            dismiss_stale_reviews=True,
+        )
 
 class TestLabelHook(unittest.TestCase):
     def test_missing(self):


### PR DESCRIPTION
Fixes #7 

The misspelled version, `dissmiss-stale-reviews` (with double s) is still honored for backwards compatibility, but a warning is printed. If present, the corrected version (`dismiss-stale-reviews`) will take precedence over the misspelled one.